### PR TITLE
Mejoras en footer, navegación y catálogo

### DIFF
--- a/contacto.html
+++ b/contacto.html
@@ -42,13 +42,13 @@
   <body>
     <header>
       <nav class="navbar navbar-expand-lg navbar-dark" style="background: linear-gradient(90deg, #ff6ec4, #7873f5);">
-        <div class="container">
+        <div class="container-fluid">
           <a class="navbar-brand" href="index.html">IDW S.A</a>
           <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
             <span class="navbar-toggler-icon"></span>
           </button>
           <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
-            <ul class="navbar-nav">
+            <ul class="navbar-nav ms-auto text-end pe-5">
               <li class="nav-item">
                 <a class="nav-link" href="index.html">Inicio</a>
               </li>

--- a/index.html
+++ b/index.html
@@ -38,13 +38,13 @@
   <body>
     <header>
       <nav class="navbar navbar-expand-lg navbar-dark" style="background: linear-gradient(90deg, #ff6ec4, #7873f5);">
-        <div class="container">
+        <div class="container-fluid">
           <a class="navbar-brand" href="index.html">IDW S.A</a>
           <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
             <span class="navbar-toggler-icon"></span>
           </button>
           <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
-            <ul class="navbar-nav">
+            <ul class="navbar-nav ms-auto text-end pe-5">
               <li class="nav-item">
                 <a class="nav-link active" href="index.html">Inicio</a>
               </li>
@@ -70,7 +70,7 @@
               <img src="assets/images/salon1.jpg" class="card-img-top" alt="Vista del Salón Arcoiris" />
               <div class="card-body">
                 <h5 class="card-title">Salón Arcoiris</h5>
-                <p class="card-text text-truncate">Ubicado en el centro. Capacidad para 50 niños.</p>
+                <p class="card-text text">Ubicado en el centro. Capacidad para 50 niños.</p>
               </div>
             </div>
           </a>
@@ -83,7 +83,7 @@
               <img src="assets/images/salon2.jpg" class="card-img-top" alt="Decoración temática de Castillo Encantado" />
               <div class="card-body">
                 <h5 class="card-title">Castillo Encantado</h5>
-                <p class="card-text text-truncate">Ideal para temáticas de princesas y superhéroes.</p>
+                <p class="card-text text">Ideal para temáticas de princesas y superhéroes.</p>
               </div>
             </div>
           </a>
@@ -96,7 +96,7 @@
               <img src="assets/images/salon3.jpg" class="card-img-top" alt="Entrada al Salón al Aire Libre" />
               <div class="card-body">
                 <h5 class="card-title">Salón al Aire Libre</h5>
-                <p class="card-text text-truncate">Con juegos inflables y animadores.</p>
+                <p class="card-text text">Con juegos inflables y animadores.</p>
               </div>
             </div>
           </a>

--- a/info.html
+++ b/info.html
@@ -44,13 +44,13 @@
   <body>
     <header>
       <nav class="navbar navbar-expand-lg navbar-dark" style="background: linear-gradient(90deg, #ff6ec4, #7873f5);">
-        <div class="container">
+        <div class="container-fluid">
           <a class="navbar-brand" href="index.html">IDW S.A</a>
           <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
             <span class="navbar-toggler-icon"></span>
           </button>
           <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
-            <ul class="navbar-nav">
+            <ul class="navbar-nav ms-auto text-end pe-5">
               <li class="nav-item">
                 <a class="nav-link" href="index.html">Inicio</a>
               </li>


### PR DESCRIPTION
• Ajusté el footer para que siempre se ubique al final de la página, sin depender del contenido. Antes quedaba a la mitad si la página tenía poco contenido.

• Eliminé el margen lateral del encabezado (barra de navegación) para que ocupe todo el ancho.

• Para cuando se utilicen resoluciones pequeñas, el menú de navegación ahora se alinea a la derecha.

• En el catálogo de salones, agregué efectos al pasar el mouse sobre los elementos y logré que el texto se adapte correctamente sin cortarse al cambiar el tamaño de pantalla.